### PR TITLE
Keep the number of seams removed less than the image width.

### DIFF
--- a/main.c
+++ b/main.c
@@ -192,7 +192,9 @@ int main()
     Mat grad = mat_alloc(width_, height_);
     Mat dp = mat_alloc(width_, height_);
 
-    for (int i = 0; i < 350; ++i) {
+    int seams_to_remove = img.width * 2 / 3;
+
+    for (int i = 0; i < seams_to_remove; ++i) {
         printf("Removing seam %d\n", i);
 
         luminance(img, lum);


### PR DESCRIPTION
This avoids crashing on small images, by computing the number of seams to remove as a fraction (`2/3`) of the image width.

Fixes #2.