### PR TITLE
minimal "energy" seam & win32 nob

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -3,6 +3,17 @@
 #define NOB_IMPLEMENTATION
 #include "nob.h"
 
+#ifdef _WIN32
+#include <stdint.h>
+static double get_time(){
+  static uint64_t f=0;
+  if (f==0) QueryPerformanceFrequency((void*)&f);
+  uint64_t t;
+  QueryPerformanceCounter((void*)&t);
+  return (double)t/f;
+}
+#else
+
 #include <time.h>
 
 double get_time(void)
@@ -13,9 +24,11 @@ double get_time(void)
     return tp.tv_sec + tp.tv_nsec*0.000000001;
 }
 
+#endif
+
 void cc(Nob_Cmd *cmd)
 {
-    nob_cmd_append(cmd, "cc");
+    nob_cmd_append(cmd, "clang");
     nob_cmd_append(cmd, "-Wall", "-Wextra", "-ggdb");
     nob_cmd_append(cmd, "-O3");
 }
@@ -26,6 +39,9 @@ bool rebuild_stb_if_needed(Nob_Cmd *cmd, const char *implementation, const char 
         cmd->count = 0;
         cc(cmd);
         nob_cmd_append(cmd, implementation);
+#ifdef _WIN32
+        nob_cmd_append(cmd, "-DSTBI_NO_SIMD");
+#endif
         nob_cmd_append(cmd, "-x", "c");
         nob_cmd_append(cmd, "-c");
         nob_cmd_append(cmd, "-o", output);
@@ -58,7 +74,9 @@ int main(int argc, char **argv)
     nob_cmd_append(&cmd, main_input);
     nob_cmd_append(&cmd, "./build/stb_image.o");
     nob_cmd_append(&cmd, "./build/stb_image_write.o");
+#ifndef _WIN32
     nob_cmd_append(&cmd, "-lm");
+#endif
     if (!nob_cmd_run_sync(cmd)) return 1;
 
     cmd.count = 0;


### PR DESCRIPTION
Selecting seam with the minimal "energy", integrated along the seam, works a bit better than seam with minimal energy of first point only, however much slower.

![output](https://github.com/tsoding/seam-carving/assets/7340070/3d516722-dca8-42be-9a0f-3b3ab8d57e1a)
![output2](https://github.com/tsoding/seam-carving/assets/7340070/4a3d31c1-1039-4564-bc63-68a3e0f67c4e)
