### PR TITLE
Switch markout_sobel_patches to an overapproximation

### DIFF
--- a/main.c
+++ b/main.c
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
             const int low_bound = seam[cy] - 2;
             const int high_bound = seam[cy] + 2;
             int cx = low_bound >= 0 ? low_bound : 0;
-            const int max = high_bound < grad.height ? high_bound : grad.height;
+            const int max = high_bound < grad.width ? high_bound : grad.width;
             for (;cx < max; ++cx) {
                 MAT_AT(grad, cy, cx) = sobel_filter_at(lum, cx, cy);
             }


### PR DESCRIPTION
We know that for a given seam point at most two points can be effected either side of it.

```
...#x##..
...##x##.
....##x##
.....##x#
```
The most extreme case

We can always assume that we affect all of these.
If we do assume this, then we can choose the range of points to recalculate quite simply.

```
..##x##..
____^
..####..
____^
```
Cursor prior to and after removing the seam point

The bounds on this range is 'seam[y] - 2' to 'seam[y] + 1'.

After extensive profiling (I ran it 5 times before and after), it does not seem to impact performance really at all (if anything my intuition would be that it would improve by a slight margin), it removes the need for the horrible type punning, and removes a function definition.